### PR TITLE
Fix crashing [#137290383]

### DIFF
--- a/lib/logstash/filters/kubernetes_metadata.rb
+++ b/lib/logstash/filters/kubernetes_metadata.rb
@@ -161,17 +161,20 @@ class LogStash::Filters::KubernetesMetadata < LogStash::Filters::Base
           'annotations' => sanatize_keys(data['metadata']['annotations']),
           'labels' => sanatize_keys(data['metadata']['labels'])
         }
+
+        begin
+          data = LogStash::Json.load(apiResponse)
+          {
+            'annotations' => sanatize_keys(data['metadata']['annotations']),
+            'labels' => sanatize_keys(data['metadata']['labels'])
+          }
+        rescue => e
+          @logger.warn("Unkown error while trying to load json response")
+        end
       rescue => e
         @logger.warn("Unknown error while getting Kubernetes metadata: #{e}")
       end
     end
-
-    data = LogStash::Json.load(apiResponse)
-    {
-      'annotations' => sanatize_keys(data['metadata']['annotations']),
-      'labels' => sanatize_keys(data['metadata']['labels'])
-    }
-
   end
 
 end

--- a/lib/logstash/filters/kubernetes_metadata.rb
+++ b/lib/logstash/filters/kubernetes_metadata.rb
@@ -155,13 +155,6 @@ class LogStash::Filters::KubernetesMetadata < LogStash::Filters::Base
 
         return nil unless response.code == 200
 
-        data = LogStash::Json.load(apiResponse)
-
-        {
-          'annotations' => sanatize_keys(data['metadata']['annotations']),
-          'labels' => sanatize_keys(data['metadata']['labels'])
-        }
-
         begin
           data = LogStash::Json.load(apiResponse)
           {

--- a/lib/logstash/filters/kubernetes_metadata.rb
+++ b/lib/logstash/filters/kubernetes_metadata.rb
@@ -161,6 +161,7 @@ class LogStash::Filters::KubernetesMetadata < LogStash::Filters::Base
             'annotations' => sanatize_keys(data['metadata']['annotations']),
             'labels' => sanatize_keys(data['metadata']['labels'])
           }
+          return data
         rescue => e
           @logger.warn("Unkown error while trying to load json response")
         end
@@ -168,6 +169,7 @@ class LogStash::Filters::KubernetesMetadata < LogStash::Filters::Base
         @logger.warn("Unknown error while getting Kubernetes metadata: #{e}")
       end
     end
+    return nil
   end
 
 end


### PR DESCRIPTION
Should fix the crashing. It looks like we're having some sort of issue loading the kube metadata, but then we try to load the response into json anyway. If we get an actual response, then the existing code catches it, but not if we have a problem with the request in the first place.